### PR TITLE
Reorganize preferences layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include $(THEOS)/makefiles/common.mk
-
+export TARGET = iphone:latest:11.0
 ARCHS = arm64 arm64e
+
 TWEAK_NAME = NotiBlock
 NotiBlock_FILES = Tweak.xm notiblockpref/NBPNotificationFilter.m notiblockpref/NBPAppInfo.m
 NotiBlock_LIBRARIES = applist

--- a/notiblockpref/Makefile
+++ b/notiblockpref/Makefile
@@ -1,8 +1,9 @@
 include $(THEOS)/makefiles/common.mk
-
+export TARGET = iphone:latest:11.0
 ARCHS = arm64 arm64e
+
 BUNDLE_NAME = NotiBlockPref
-NotiBlockPref_FILES = NBPAppInfo.m NBPRootPreferenceController.m NBPRootTableViewController.m NBPAddViewController.m NBPButtonTableViewCell.m NBPPickerTableViewCell.m NBPSwitchTableViewCell.m NBPTextEntryTableViewCell.m NBPWeekDayTableViewCell.m NBPNotificationFilter.m NBPDatePickerTableViewCell.m NBPAppChooserViewController.m NBPAppListTableViewCell.m NBPImageTableViewCell.m
+NotiBlockPref_FILES = $(wildcard *.m)
 NotiBlockPref_INSTALL_PATH = /Library/PreferenceBundles
 NotiBlockPref_FRAMEWORKS = UIKit
 NotiBlockPref_PRIVATE_FRAMEWORKS = Preferences

--- a/notiblockpref/NBPAddViewController.m
+++ b/notiblockpref/NBPAddViewController.m
@@ -318,20 +318,20 @@ typedef NS_ENUM(NSUInteger, Section) {
         case SectionFieldFilter: {
             switch (indexPath.row) {
                 case 0:
-                    if (self.notificationFilterFieldPickerCell.picker.tag == 0) return 200;
+                    if (self.notificationFilterFieldPickerCell.picker.tag) return 200;
                     break;
                 case 1:
-                    if (self.blockTypePickerCell.picker.tag == 0) return 200;
+                    if (self.blockTypePickerCell.picker.tag) return 200;
                     break;
             } break;
         }
         case SectionBlockOnSchedule: {
             switch (indexPath.row) {
                 case 1:
-                    if (self.startTimeCell.datePicker.tag == 0) return 200;
+                    if (self.startTimeCell.datePicker.tag) return 200;
                     break;
                 case 2:
-                    if (self.endTimeCell.datePicker.tag == 0) return 200;
+                    if (self.endTimeCell.datePicker.tag) return 200;
                     break;
             } break;
         }

--- a/notiblockpref/NBPAddViewController.m
+++ b/notiblockpref/NBPAddViewController.m
@@ -141,7 +141,7 @@ typedef NS_ENUM(NSUInteger, Section) {
         [self.weekDayCell  setWeekDays:[self.currentFilter.weekDays mutableCopy]];
         
     } else {
-        self.title = @"New Notification Filter";
+        self.title = @"New Filter";
         self.currentFilter = [[NotificationFilter alloc] init];
         [self.notificationFilterFieldPickerCell setPickerIndex:0];
         saveButtonText = @"Create";
@@ -195,23 +195,30 @@ typedef NS_ENUM(NSUInteger, Section) {
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
         case SectionFilterName:
-            return @"Filter Name";
+            return @"Name";
         case SectionExampleBanner:
-            return @"Notification Example";
+            return @"Example Notification";
         case SectionFieldFilter:
-            return @"Notification Filter Settings";
+            return @"Filter Criteria";
         case SectionAppFilter:
-            return @"App To Filter";
-        case SectionWhitelistMode:
-            return @"By Setting Whitelist Mode to true, only notifications that match your filter they will be allowed, all others will be blocked. Note if you use a whitelist filter, you cannot combine with any other filters for that app. If you need to whitelist multiple things, you will need to use regex. Ex, set whitelist to true, select regex filter, and enter “^(Tomer:|Alex:)” would block all notifications from an app that didn’t start with Tomer: or Alex: blocking everyone else out.";
-        case SectionShowInNotificationCenter:
-            return @"By turning Show In Notification Center to true, the notification will not make a sound, wake your phone, or show a banner, but will still show up in the notification center/lockscreen.";
-        case SectionBlockOnSchedule:
-            return @"When blocking on a schedule, The filter is only active in between the start time and end time on days that are selected as green. If the notification happens on a day that is red, or outside the window, it will be allowed through.";
-    }  
-    return @"";  
+            return @"Filter by App";
+    }
+    
+    return nil;
 }
 
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    switch (section) {
+        case SectionWhitelistMode:
+            return @"Invert the filter criteria: only notifications that match this will be allowed. Note that whitelist filters cannot be combined with any other filters for that app. If you need to whitelist multiple things, you will need to use a regex.\n\nExample: enable Whitelist Mode, select the regex filter, and enter “^(Tomer|Alex):” to block all notifications from an app that don't start with ”Tomer:” or ”Alex:”, blocking everything else.";
+        case SectionShowInNotificationCenter:
+            return @"Prevent the notification from making sounds sound, waking your device, or showing banners. It will still show up on the lockscreen.";
+        case SectionBlockOnSchedule:
+            return @"Schedule when to activate this filter. The filter will only activate in the given timeframe on the selected days (in green). If the notification happens on a day that is red or outside the timeframe, it will not be blocked.";
+    }  
+    
+    return nil;
+}
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {

--- a/notiblockpref/NBPAppChooserViewController.m
+++ b/notiblockpref/NBPAppChooserViewController.m
@@ -134,7 +134,7 @@
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    return 50;
+    return 44;
 }
 
 @end

--- a/notiblockpref/NBPAppListTableViewCell.m
+++ b/notiblockpref/NBPAppListTableViewCell.m
@@ -27,8 +27,8 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
-    self.appIcon.frame = CGRectMake(17.5, 7.5, 35, 35);
-    self.appName.frame = CGRectMake(70, 0, screenWidth-70, 50);
+    self.appIcon.frame = CGRectMake(17.5, 7.5, 30, 30);
+    self.appName.frame = CGRectMake(70, 0, screenWidth-70, 44);
 }
 
 @end

--- a/notiblockpref/NBPButtonTableViewCell.m
+++ b/notiblockpref/NBPButtonTableViewCell.m
@@ -26,7 +26,7 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
-    self.buttonTextLabel.frame = CGRectMake(15, 0, screenWidth, 50);
+    self.buttonTextLabel.frame = CGRectMake(15, 0, screenWidth, 44);
 }
 
 

--- a/notiblockpref/NBPDatePickerTableViewCell.m
+++ b/notiblockpref/NBPDatePickerTableViewCell.m
@@ -36,9 +36,9 @@
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
     int vertHeight = 0;
-    self.descriptionLabel.frame = CGRectMake(15, vertHeight, 150, 50);
-    self.selectedTimeLabel.frame = CGRectMake(0, vertHeight, screenWidth - 15, 50);
-    vertHeight+=50;
+    self.descriptionLabel.frame = CGRectMake(15, vertHeight, 150, 44);
+    self.selectedTimeLabel.frame = CGRectMake(0, vertHeight, screenWidth - 15, 44);
+    vertHeight+=44;
     self.datePicker.frame = CGRectMake(0, vertHeight, screenWidth, 150);
 }
 

--- a/notiblockpref/NBPPickerTableViewCell.m
+++ b/notiblockpref/NBPPickerTableViewCell.m
@@ -37,9 +37,9 @@
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
     int vertHeight = 0;
-    self.descriptionLabel.frame = CGRectMake(15, vertHeight, 200, 50);
-    self.selectedLabel.frame = CGRectMake(0, vertHeight, screenWidth-15, 50);
-    vertHeight+=50;
+    self.descriptionLabel.frame = CGRectMake(15, vertHeight, 200, 44);
+    self.selectedLabel.frame = CGRectMake(0, vertHeight, screenWidth-15, 44);
+    vertHeight+=44;
     self.picker.frame = CGRectMake((screenWidth - 225)/2, vertHeight, 225, 150);
 }
 

--- a/notiblockpref/NBPRootTableViewController.m
+++ b/notiblockpref/NBPRootTableViewController.m
@@ -1,9 +1,3 @@
-#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
-#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
-
 #import "NBPRootTableViewController.h"
 #import <Cephei/HBPreferences.h>
 
@@ -33,7 +27,7 @@
     NBPAddViewController *one = [[NBPAddViewController alloc]init];
 	one.delegate = self;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:one];
-	if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
+	if (@available(iOS 13.0, *)) {
         navController.modalInPresentation = YES;
 	}
 	
@@ -76,7 +70,7 @@
 	one.currentFilter = [self.filterList objectAtIndex:indexPath.row];
 
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:one];
-	if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
+	if (@available(iOS 13.0, *)) {
         navController.modalInPresentation = YES;
 	}
 		

--- a/notiblockpref/NBPSwitchTableViewCell.m
+++ b/notiblockpref/NBPSwitchTableViewCell.m
@@ -28,9 +28,14 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    int screenWidth = self.frame.size.width;
-    self.switchLabel.frame = CGRectMake(15, 0, 250, 50);
-    self.cellSwitch.frame = CGRectMake(screenWidth-66, 9, 51, 31);
+    
+    CGFloat screenWidth = self.frame.size.width;
+    self.switchLabel.frame = CGRectMake(15, 0, 250, 44);
+    
+    self.cellSwitch.center = self.contentView.center;
+    CGRect switchFrame = self.cellSwitch.frame;
+    switchFrame.origin.x = screenWidth-66;
+    self.cellSwitch.frame = switchFrame;
 }
 
 

--- a/notiblockpref/NBPTextEntryTableViewCell.m
+++ b/notiblockpref/NBPTextEntryTableViewCell.m
@@ -24,7 +24,7 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
-    self.textField.frame = CGRectMake(15, 0, screenWidth, 50);
+    self.textField.frame = CGRectMake(15, 0, screenWidth, 44);
 }
 
 @end

--- a/notiblockpref/NBPWeekDayTableViewCell.m
+++ b/notiblockpref/NBPWeekDayTableViewCell.m
@@ -45,7 +45,7 @@
     [super layoutSubviews];
     int screenWidth = self.frame.size.width;
     for (int i = 0; i < 7; i++) {
-        ((UIButton *)self.weekDayButtons[i]).frame = CGRectMake(i*(screenWidth/7+1), 0, (screenWidth/7 + 1), 50);
+        ((UIButton *)self.weekDayButtons[i]).frame = CGRectMake(i*(screenWidth/7+1), 0, (screenWidth/7 + 1), 44);
     }
 }
 

--- a/notiblockpref/Resources/Root.plist
+++ b/notiblockpref/Resources/Root.plist
@@ -18,23 +18,17 @@
 		</dict>
 		<dict>
 			<key>cell</key>
-			<string>PSGroupCell</string>
-			<key>label</key>
-			<string>NotiBlock Settings</string>
-		</dict>
-		<dict>
-			<key>cell</key>
 			<string>PSLinkListCell</string>
 			<key>label</key>
-			<string>Notification Filter List</string>
+			<string>Active Filters</string>
 			<key>action</key>
 			<string>viewFilters</string>
 		</dict>
 		<dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>
-			<key>label</key>
-			<string>Respring for changes to take affect</string>
+			<key>footerText</key>
+			<string>A respring is necessary for changes to take effect.</string>
 		</dict>
 		<dict>
 			<key>cell</key>
@@ -47,22 +41,16 @@
 		<dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>
-			<key>label</key>
-			<string>View the source code for this tweak</string>
+			<key>footerText</key>
+			<string>Help Support my development of free, opensource tweaks by donating.</string>
 		</dict>
 		<dict>
 			<key>cellClass</key>
 			<string>HBLinkTableCell</string>
 			<key>label</key>
-			<string>View on Github</string>
+			<string>View Source on Github</string>
 			<key>url</key>
 			<string>https://github.com/eclair4151/NotiBlock</string>
-		</dict>
-		<dict>
-			<key>cell</key>
-			<string>PSGroupCell</string>
-			<key>label</key>
-			<string>Help Support my development of free, opensource tweaks</string>
 		</dict>
 		<dict>
 			<key>cellClass</key>


### PR DESCRIPTION
This PR makes the changes depicted in the screenshots below, fixes some bugs I mistakenly left in my previous PR, and adds the `TARGET` variable to the Makefiles which silences some warnings by setting the minimum deployment target to iOS 13.

Please review the differences in the screenshots thoroughly before you accept this PR! I adjusted the text of several labels and descriptions.

<img width="50%" alt="Root preferences screen" src="https://user-images.githubusercontent.com/8371943/119173011-3bd3dd80-ba2c-11eb-8fa3-5ee9d14cde12.jpeg">
<img width="50%" alt="New filter screen" src="https://user-images.githubusercontent.com/8371943/119173003-3aa2b080-ba2c-11eb-940f-ddb4cd5a1a26.jpeg">
